### PR TITLE
fix oven recipe and tarte skillet issue

### DIFF
--- a/src/main/java/com/lance5057/extradelight/ExtraDelightItems.java
+++ b/src/main/java/com/lance5057/extradelight/ExtraDelightItems.java
@@ -30,6 +30,7 @@ import com.lance5057.extradelight.items.OffsetSpatulaItem;
 import com.lance5057.extradelight.items.ShuckableCorn;
 import com.lance5057.extradelight.items.ToolTipConsumableItem;
 import com.lance5057.extradelight.items.XocolatlItem;
+import com.lance5057.extradelight.items.dynamicfood.DynamicContainerFeastItem;
 import com.lance5057.extradelight.items.dynamicfood.DynamicJam;
 import com.lance5057.extradelight.items.dynamicfood.DynamicToast;
 import com.lance5057.extradelight.items.dynamicfood.api.DynamicItemComponent;
@@ -2689,19 +2690,8 @@ public class ExtraDelightItems {
 			.advancementMeal().isHotFood().finish();
 
 	public static final DeferredItem<Item> TARTE_TATIN_IN_PAN = EDItemGenerator
-			.register("tarte_tatin_in_pan", () -> new SolidBucketItem(ExtraDelightBlocks.TARTE_TATIN.get(),
-					SoundEvents.DYE_USE, stack1Item()) {
-				@Override
-				public InteractionResult useOn(UseOnContext context) {
-					InteractionResult interactionresult = super.useOn(context);
-					Player player = context.getPlayer();
-					if (interactionresult.consumesAction() && player != null) {
-						player.setItemInHand(context.getHand(), new ItemStack(ModItems.SKILLET.get()));
-					}
-
-					return interactionresult;
-				}
-			}).advancementFeast().finish();
+			.register("tarte_tatin_in_pan", () -> new DynamicContainerFeastItem(ExtraDelightBlocks.TARTE_TATIN.get(),
+					SoundEvents.DYE_USE, stack1Item().craftRemainder(ModItems.SKILLET.get()))).advancementFeast().finish();
 
 	public static final DeferredItem<Item> TARTE_TATIN = EDItemGenerator
 			.register("tarte_tatin", () -> new BlockItem(ExtraDelightBlocks.TARTE_TATIN.get(), stack1Item()))

--- a/src/main/java/com/lance5057/extradelight/items/dynamicfood/DynamicContainerFeastItem.java
+++ b/src/main/java/com/lance5057/extradelight/items/dynamicfood/DynamicContainerFeastItem.java
@@ -1,0 +1,54 @@
+package com.lance5057.extradelight.items.dynamicfood;
+
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.SolidBucketItem;
+import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.block.Block;
+import vectorwing.farmersdelight.common.item.component.ItemStackWrapper;
+import vectorwing.farmersdelight.common.registry.ModDataComponents;
+
+import java.util.Optional;
+
+public class DynamicContainerFeastItem extends SolidBucketItem {
+
+    public DynamicContainerFeastItem(
+            Block p_151187_,
+            SoundEvent p_151188_,
+            Properties p_151189_
+    ) {
+        super(p_151187_, p_151188_, p_151189_);
+    }
+
+    @Override
+    public InteractionResult useOn(UseOnContext context) {
+        ItemStack cached = context.getItemInHand().copy();
+        InteractionResult interactionresult = super.useOn(context);
+        Player player = context.getPlayer();
+
+        if (interactionresult.consumesAction() && player != null) {
+            player.setItemInHand(context.getHand(), getCraftingRemainingItem(cached));
+        }
+
+        return interactionresult;
+    }
+
+    public ItemStack getCraftingRemainingItem(ItemStack itemStack)
+    {
+        if (!hasCraftingRemainingItem(itemStack)) {
+            return ItemStack.EMPTY;
+        }
+        var toReturn = Optional.ofNullable(itemStack.get(ModDataComponents.CONTAINER))
+                .map(ItemStackWrapper::getStack)
+                .orElse(Items.ACACIA_BOAT.getDefaultInstance());
+        if (toReturn.isEmpty()) {
+            assert this.getCraftingRemainingItem() != null;
+            return new ItemStack(this.getCraftingRemainingItem());
+        }
+        return toReturn;
+    }
+
+}

--- a/src/main/java/com/lance5057/extradelight/workstations/oven/OvenBlockEntity.java
+++ b/src/main/java/com/lance5057/extradelight/workstations/oven/OvenBlockEntity.java
@@ -269,7 +269,7 @@ public class OvenBlockEntity extends SyncedBlockEntity
 
 	protected boolean canCook(OvenRecipe recipe) {
 		if (hasInput()) {
-			ItemStack resultStack = recipe.getResultItem(this.level.registryAccess());
+			ItemStack resultStack = recipe.assemble(new RecipeWrapper(inventory), this.level.registryAccess()).copy();
 
 			// Vessel Required
 			if (inventory.getStackInSlot(CONTAINER_SLOT).getItem() != recipe.getOutputContainer().getItem())
@@ -307,7 +307,7 @@ public class OvenBlockEntity extends SyncedBlockEntity
 		cookTime = 0;
 		mealContainerStack = recipe.value().getOutputContainer();
 		ItemStack containerInputStack = inventory.getStackInSlot(CONTAINER_SLOT);
-		ItemStack resultStack = recipe.value().getResultItem(this.level.registryAccess());
+		ItemStack resultStack = recipe.value().assemble(new RecipeWrapper(inventory), this.level.registryAccess()).copy();
 		ItemStack storedMealStack = inventory.getStackInSlot(OUTPUT_SLOT);
 		if (storedMealStack.isEmpty()) {
 			inventory.setStackInSlot(OUTPUT_SLOT, resultStack.copy());

--- a/src/main/java/com/lance5057/extradelight/workstations/oven/recipes/OvenRecipe.java
+++ b/src/main/java/com/lance5057/extradelight/workstations/oven/recipes/OvenRecipe.java
@@ -1,7 +1,9 @@
 package com.lance5057.extradelight.workstations.oven.recipes;
 
+import com.lance5057.extradelight.ExtraDelight;
 import com.lance5057.extradelight.ExtraDelightItems;
 import com.lance5057.extradelight.ExtraDelightRecipes;
+import com.lance5057.extradelight.items.dynamicfood.DynamicContainerFeastItem;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
@@ -18,11 +20,14 @@ import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.common.util.RecipeMatcher;
 import net.neoforged.neoforge.items.wrapper.RecipeWrapper;
+import vectorwing.farmersdelight.common.item.component.ItemStackWrapper;
+import vectorwing.farmersdelight.common.registry.ModDataComponents;
 
 public class OvenRecipe implements Recipe<RecipeWrapper> {
 	public static final int INPUT_SLOTS = 9;
+    public static final int CONTAINER_SLOT = 10;
 
-	private final String group;
+    private final String group;
 //	private final OvenRecipeBookTab tab;
 	private final NonNullList<Ingredient> inputItems;
 	public final ItemStack output;
@@ -82,8 +87,12 @@ public class OvenRecipe implements Recipe<RecipeWrapper> {
 	}
 
 	@Override
-	public ItemStack assemble(RecipeWrapper input, Provider registries) {
-		return this.output.copy();
+	public ItemStack assemble(RecipeWrapper recipeWrapper, Provider registries) {
+		ItemStack result = output.copy();
+        if(result.getItem() instanceof DynamicContainerFeastItem && !recipeWrapper.getItem(CONTAINER_SLOT).isEmpty()){
+            result.set(ModDataComponents.CONTAINER.get(), new ItemStackWrapper(recipeWrapper.getItem(CONTAINER_SLOT).copyWithCount(1)));
+        }
+        return result;
 	}
 
 	public float getExperience() {


### PR DESCRIPTION
This is to fix the known bug: If you have an enchanted/damaged skillet and use it to make Cornbread or the Tarte Tatin you will just get a regular/undamaged one back.

Changes:
1. Oven block entity uses OvenRecipe#assemble to create result items. 
2. A new Item Class `DynamicContainerFeastItem` for tarte is made. Its crafting remainder and left over item after placing is determined dynamically with FD's CONTAINER data component.
3. OvenRecipe#assemble checks if the result item is `DynamicContainerFeastItem` and write the container item into result's CONTAINER datacomponent.